### PR TITLE
Fix URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ https://eeeps.github.io/cam02-color-schemer
 
 A tool for creating color schemes, built on the CIECAM02 color appearance model.
 
-[CIECAM02](https://en.wikipedia.org/wiki/CIECAM02) was built with a deep physiological understanding of how the eye and brain actually perceive, *plus* a whole lot of math that I don’t understand. This lil’ color schemer was built on [Connor Gramazio](gramaz.io)’s implementation of CIECAM02 in [D3](https://d3js.org), and I can’t explain [what CIECAM02 is](gramaz.io/d3-cam02/#ciecam02) (or show you [how good it is at blending colors](http://gramaz.io/d3-cam02/#cam02vsLab)) any better than he does.
+[CIECAM02](https://en.wikipedia.org/wiki/CIECAM02) was built with a deep physiological understanding of how the eye and brain actually perceive, *plus* a whole lot of math that I don’t understand. This lil’ color schemer was built on [Connor Gramazio](https://gramaz.io)’s implementation of CIECAM02 in [D3](https://d3js.org), and I can’t explain [what CIECAM02 is](https://gramaz.io/d3-cam02/#ciecam02) (or show you [how good it is at blending colors](https://gramaz.io/d3-cam02/#cam02vsLab)) any better than he does.


### PR DESCRIPTION
Two of the URLs in the README were missing the scheme (https), which didn't allow them to be followed; and a third one used http when the site is available via https.